### PR TITLE
fix: resolve composer install dependency issues for 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to `laravel-error-analyzer` will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Resolved `composer install` failure caused by requiring unsupported `illuminate/foundation` for Laravel 11/12
+
+### Changed
+- Removed unused dependencies (`illuminate/notifications`, `mockery/mockery`)
+- Updated Japanese README optional dependency instructions to match current implementation
+
 ### Added
 - Initial release
 - AI-driven error analysis using Google Gemini

--- a/README-ja.md
+++ b/README-ja.md
@@ -73,9 +73,6 @@ ERROR_ANALYZER_STORAGE_DRIVER=database  # 'database'（既定） or 'null'（DB�
 ```bash
 # Gemini AI 分析
 composer require google-gemini-php/laravel
-
-# Slack 通知
-composer require laravel/slack-notification-channel
 ```
 
 ## 基本的な使い方

--- a/composer.json
+++ b/composer.json
@@ -24,19 +24,16 @@
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/database": "^11.0|^12.0",
         "illuminate/queue": "^11.0|^12.0",
-        "illuminate/http": "^11.0|^12.0",
-        "illuminate/notifications": "^11.0|^12.0"
+        "illuminate/http": "^11.0|^12.0"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^11.0",
-        "mockery/mockery": "^1.6",
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.13"
     },
     "suggest": {
-        "google-gemini-php/laravel": "Required for Gemini AI error analysis (^2.0)",
-        "laravel/slack-notification-channel": "Required for Slack notifications (^3.4)"
+        "google-gemini-php/laravel": "Required for Gemini AI error analysis (^2.0)"
     },
     "autoload": {
         "psr-4": {

--- a/src/Jobs/AnalyzeErrorJob.php
+++ b/src/Jobs/AnalyzeErrorJob.php
@@ -7,7 +7,6 @@ namespace Lbose\ErrorAnalyzer\Jobs;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
@@ -28,7 +27,6 @@ use Throwable;
  */
 class AnalyzeErrorJob implements ShouldQueue
 {
-    use Dispatchable;
     use InteractsWithQueue;
     use Queueable;
     use SerializesModels;


### PR DESCRIPTION
## Summary
- fix `composer install` failure by removing unsupported `illuminate/foundation` usage
- remove unused dependencies (`illuminate/notifications`, `mockery/mockery`)
- align `README-ja.md` optional dependency instructions with current implementation
- add changelog notes under `Unreleased` for the next release (`0.1.2`)

## Validation
- `composer validate --no-check-publish`
- `php -l src/Jobs/AnalyzeErrorJob.php`

## Release note
After merging this PR, create and push tag `0.1.2` (or `v0.1.2` if you standardize on `v` prefix) to publish the next package version on Packagist.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lbose-corp/laravel-error-analyzer/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
