### PR TITLE
docs: fix Japanese README migration install steps

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -31,10 +31,9 @@ composer require lbose/laravel-error-analyzer
 php artisan vendor:publish --tag=error-analyzer-config
 ```
 
-マイグレーションを公開して実行します。
+マイグレーションを実行します（`ERROR_ANALYZER_STORAGE_DRIVER=database` の場合、パッケージのマイグレーションは自動ロードされます）。
 
 ```bash
-php artisan vendor:publish --tag=error-analyzer-migrations
 php artisan migrate
 ```
 


### PR DESCRIPTION
## Summary
- remove outdated vendor:publish step for package migrations from README-ja
- clarify that package migrations are auto-loaded when database storage is enabled
- align Japanese installation instructions with the current implementation and English README

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lbose-corp/laravel-error-analyzer/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
